### PR TITLE
feat: add software upgrade admin proposal #ntrn-314

### DIFF
--- a/packages/neutron-sdk/schema/neutron_msg.json
+++ b/packages/neutron-sdk/schema/neutron_msg.json
@@ -295,6 +295,17 @@
               "type": "null"
             }
           ]
+        },
+        "software_upgrade_proposal": {
+          "description": "*software_upgrade_proposal** is a software upgrade proposal field.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SoftwareUpgradeProposal"
+            },
+            {
+              "type": "null"
+            }
+          ]
         }
       }
     },
@@ -400,7 +411,7 @@
       ],
       "properties": {
         "description": {
-          "description": "*descriptionr** is a text description of proposal. Non unique.",
+          "description": "*description** is a text description of proposal. Non unique.",
           "type": "string"
         },
         "param_changes": {
@@ -412,6 +423,30 @@
         },
         "title": {
           "description": "*title** is a text title of proposal. Non unique.",
+          "type": "string"
+        }
+      }
+    },
+    "Plan": {
+      "description": "Plan defines the struct for planned upgrade.",
+      "type": "object",
+      "required": [
+        "height",
+        "info",
+        "name"
+      ],
+      "properties": {
+        "height": {
+          "description": "*height** is a height at which the upgrade must be performed",
+          "type": "integer",
+          "format": "int64"
+        },
+        "info": {
+          "description": "*info** is any application specific upgrade info to be included on-chain",
+          "type": "string"
+        },
+        "name": {
+          "description": "*name** is a name for the upgrade",
           "type": "string"
         }
       }
@@ -456,6 +491,33 @@
           ],
           "format": "uint64",
           "minimum": 0.0
+        }
+      }
+    },
+    "SoftwareUpgradeProposal": {
+      "description": "SoftwareUpgradeProposal defines the struct for software upgrade proposal.",
+      "type": "object",
+      "required": [
+        "description",
+        "plan",
+        "title"
+      ],
+      "properties": {
+        "description": {
+          "description": "*description** is a text description of proposal. Non unique.",
+          "type": "string"
+        },
+        "plan": {
+          "description": "*plan** is a plan of upgrade.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Plan"
+            }
+          ]
+        },
+        "title": {
+          "description": "*title** is a text title of proposal. Non unique.",
+          "type": "string"
         }
       }
     },

--- a/packages/neutron-sdk/schema/neutron_msg.json
+++ b/packages/neutron-sdk/schema/neutron_msg.json
@@ -282,43 +282,48 @@
   ],
   "definitions": {
     "AdminProposal": {
-      "description": "AdminProposal defines the struct for various proposals which Neutron's Admin Module may accept. Currently only parameter change proposals are implemented, new types of admin proposals may be implemented in future.",
-      "type": "object",
-      "properties": {
-        "cancel_software_upgrade_proposal": {
-          "description": "*cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.",
-          "anyOf": [
-            {
-              "$ref": "#/definitions/CancelSoftwareUpgradeProposal"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "param_change_proposal": {
+      "description": "AdminProposal defines the struct for various proposals which Neutron's Admin Module may accept.",
+      "oneOf": [
+        {
           "description": "*param_change_proposal** is a parameter change proposal field.",
-          "anyOf": [
-            {
+          "type": "object",
+          "required": [
+            "param_change_proposal"
+          ],
+          "properties": {
+            "param_change_proposal": {
               "$ref": "#/definitions/ParamChangeProposal"
-            },
-            {
-              "type": "null"
             }
-          ]
+          },
+          "additionalProperties": false
         },
-        "software_upgrade_proposal": {
+        {
           "description": "*software_upgrade_proposal** is a software upgrade proposal field.",
-          "anyOf": [
-            {
+          "type": "object",
+          "required": [
+            "software_upgrade_proposal"
+          ],
+          "properties": {
+            "software_upgrade_proposal": {
               "$ref": "#/definitions/SoftwareUpgradeProposal"
-            },
-            {
-              "type": "null"
             }
-          ]
+          },
+          "additionalProperties": false
+        },
+        {
+          "description": "*cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.",
+          "type": "object",
+          "required": [
+            "cancel_software_upgrade_proposal"
+          ],
+          "properties": {
+            "cancel_software_upgrade_proposal": {
+              "$ref": "#/definitions/CancelSoftwareUpgradeProposal"
+            }
+          },
+          "additionalProperties": false
         }
-      }
+      ]
     },
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",

--- a/packages/neutron-sdk/schema/neutron_msg.json
+++ b/packages/neutron-sdk/schema/neutron_msg.json
@@ -285,6 +285,17 @@
       "description": "AdminProposal defines the struct for various proposals which Neutron's Admin Module may accept. Currently only parameter change proposals are implemented, new types of admin proposals may be implemented in future.",
       "type": "object",
       "properties": {
+        "cancel_software_upgrade_proposal": {
+          "description": "*cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CancelSoftwareUpgradeProposal"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "param_change_proposal": {
           "description": "*param_change_proposal** is a parameter change proposal field.",
           "anyOf": [
@@ -312,6 +323,24 @@
     "Binary": {
       "description": "Binary is a wrapper around Vec<u8> to add base64 de/serialization with serde. It also adds some helper methods to help encode inline.\n\nThis is only needed as serde-json-{core,wasm} has a horrible encoding for Vec<u8>. See also <https://github.com/CosmWasm/cosmwasm/blob/main/docs/MESSAGE_TYPES.md>.",
       "type": "string"
+    },
+    "CancelSoftwareUpgradeProposal": {
+      "description": "CancelSoftwareUpgradeProposal defines the struct for cancel software upgrade proposal.",
+      "type": "object",
+      "required": [
+        "description",
+        "title"
+      ],
+      "properties": {
+        "description": {
+          "description": "*description** is a text description of proposal. Non unique.",
+          "type": "string"
+        },
+        "title": {
+          "description": "*title** is a text title of proposal. Non unique.",
+          "type": "string"
+        }
+      }
     },
     "Coin": {
       "type": "object",

--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -253,7 +253,7 @@ impl NeutronMsg {
         proposal: CancelSoftwareUpgradeProposal,
     ) -> Self {
         NeutronMsg::SubmitAdminProposal {
-            admin_proposal: AdminProposal::CancelSoftwareUpgradeProposal(proposal)
+            admin_proposal: AdminProposal::CancelSoftwareUpgradeProposal(proposal),
         }
     }
 }

--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -237,6 +237,18 @@ impl NeutronMsg {
         NeutronMsg::SubmitAdminProposal {
             admin_proposal: AdminProposal {
                 param_change_proposal: Option::from(proposal),
+                software_upgrade_proposal: None,
+            },
+        }
+    }
+
+    /// Basic helper to define a parameter change proposal passed to AdminModule:
+    /// * **proposal** is struct which contains proposal that should change network parameter.
+    pub fn submit_software_upgrade_proposal(proposal: SoftwareUpgradeProposal) -> Self {
+        NeutronMsg::SubmitAdminProposal {
+            admin_proposal: AdminProposal {
+                param_change_proposal: None,
+                software_upgrade_proposal: Option::from(proposal),
             },
         }
     }
@@ -285,6 +297,8 @@ pub struct MsgIbcTransferResponse {
 pub struct AdminProposal {
     /// **param_change_proposal** is a parameter change proposal field.
     pub param_change_proposal: Option<ParamChangeProposal>,
+    /// **software_upgrade_proposal** is a software upgrade proposal field.
+    pub software_upgrade_proposal: Option<SoftwareUpgradeProposal>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -293,7 +307,7 @@ pub struct AdminProposal {
 pub struct ParamChangeProposal {
     /// **title** is a text title of proposal. Non unique.
     pub title: String,
-    /// **descriptionr** is a text description of proposal. Non unique.
+    /// **description** is a text description of proposal. Non unique.
     pub description: String,
     /// **param_changes** is a vector of params to be changed. Non unique.
     pub param_changes: Vec<ParamChange>,
@@ -309,4 +323,28 @@ pub struct ParamChange {
     pub key: String,
     /// **value** is a new value for given parameter. Non unique.
     pub value: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// SoftwareUpgradeProposal defines the struct for software upgrade proposal.
+pub struct SoftwareUpgradeProposal {
+    /// **title** is a text title of proposal. Non unique.
+    pub title: String,
+    /// **description** is a text description of proposal. Non unique.
+    pub description: String,
+    /// **plan** is a plan of upgrade.
+    pub plan: Plan,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// Plan defines the struct for planned upgrade.
+pub struct Plan {
+    /// **name** is a name for the upgrade
+    pub name: String,
+    /// **height** is a height at which the upgrade must be performed
+    pub height: i64,
+    /// **info** is any application specific upgrade info to be included on-chain
+    pub info: String,
 }

--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -235,11 +235,7 @@ impl NeutronMsg {
     /// * **proposal** is struct which contains proposal that should change network parameter.
     pub fn submit_param_change_proposal(proposal: ParamChangeProposal) -> Self {
         NeutronMsg::SubmitAdminProposal {
-            admin_proposal: AdminProposal {
-                param_change_proposal: Option::from(proposal),
-                software_upgrade_proposal: None,
-                cancel_software_upgrade_proposal: None,
-            },
+            admin_proposal: AdminProposal::ParamChangeProposal(proposal),
         }
     }
 
@@ -247,11 +243,7 @@ impl NeutronMsg {
     /// * **proposal** is struct which contains proposal that sets upgrade block.
     pub fn submit_software_upgrade_proposal(proposal: SoftwareUpgradeProposal) -> Self {
         NeutronMsg::SubmitAdminProposal {
-            admin_proposal: AdminProposal {
-                param_change_proposal: None,
-                software_upgrade_proposal: Option::from(proposal),
-                cancel_software_upgrade_proposal: None,
-            },
+            admin_proposal: AdminProposal::SoftwareUpgradeProposal(proposal),
         }
     }
 
@@ -261,11 +253,7 @@ impl NeutronMsg {
         proposal: CancelSoftwareUpgradeProposal,
     ) -> Self {
         NeutronMsg::SubmitAdminProposal {
-            admin_proposal: AdminProposal {
-                param_change_proposal: None,
-                software_upgrade_proposal: None,
-                cancel_software_upgrade_proposal: Option::from(proposal),
-            },
+            admin_proposal: AdminProposal::CancelSoftwareUpgradeProposal(proposal)
         }
     }
 }
@@ -309,14 +297,13 @@ pub struct MsgIbcTransferResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 /// AdminProposal defines the struct for various proposals which Neutron's Admin Module may accept.
-/// Currently only parameter change proposals are implemented, new types of admin proposals may be implemented in future.
-pub struct AdminProposal {
+pub enum AdminProposal {
     /// **param_change_proposal** is a parameter change proposal field.
-    pub param_change_proposal: Option<ParamChangeProposal>,
+    ParamChangeProposal(ParamChangeProposal),
     /// **software_upgrade_proposal** is a software upgrade proposal field.
-    pub software_upgrade_proposal: Option<SoftwareUpgradeProposal>,
+    SoftwareUpgradeProposal(SoftwareUpgradeProposal),
     /// **cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.
-    pub cancel_software_upgrade_proposal: Option<CancelSoftwareUpgradeProposal>,
+    CancelSoftwareUpgradeProposal(CancelSoftwareUpgradeProposal),
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -238,17 +238,33 @@ impl NeutronMsg {
             admin_proposal: AdminProposal {
                 param_change_proposal: Option::from(proposal),
                 software_upgrade_proposal: None,
+                cancel_software_upgrade_proposal: None,
             },
         }
     }
 
     /// Basic helper to define a parameter change proposal passed to AdminModule:
-    /// * **proposal** is struct which contains proposal that should change network parameter.
+    /// * **proposal** is struct which contains proposal that sets upgrade block.
     pub fn submit_software_upgrade_proposal(proposal: SoftwareUpgradeProposal) -> Self {
         NeutronMsg::SubmitAdminProposal {
             admin_proposal: AdminProposal {
                 param_change_proposal: None,
                 software_upgrade_proposal: Option::from(proposal),
+                cancel_software_upgrade_proposal: None,
+            },
+        }
+    }
+
+    /// Basic helper to define a parameter change proposal passed to AdminModule:
+    /// * **proposal** is struct which contains proposal that cancels software upgrade.
+    pub fn submit_cancel_software_upgrade_proposal(
+        proposal: CancelSoftwareUpgradeProposal,
+    ) -> Self {
+        NeutronMsg::SubmitAdminProposal {
+            admin_proposal: AdminProposal {
+                param_change_proposal: None,
+                software_upgrade_proposal: None,
+                cancel_software_upgrade_proposal: Option::from(proposal),
             },
         }
     }
@@ -299,6 +315,8 @@ pub struct AdminProposal {
     pub param_change_proposal: Option<ParamChangeProposal>,
     /// **software_upgrade_proposal** is a software upgrade proposal field.
     pub software_upgrade_proposal: Option<SoftwareUpgradeProposal>,
+    /// **cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.
+    pub cancel_software_upgrade_proposal: Option<CancelSoftwareUpgradeProposal>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -335,6 +353,16 @@ pub struct SoftwareUpgradeProposal {
     pub description: String,
     /// **plan** is a plan of upgrade.
     pub plan: Plan,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+/// CancelSoftwareUpgradeProposal defines the struct for cancel software upgrade proposal.
+pub struct CancelSoftwareUpgradeProposal {
+    /// **title** is a text title of proposal. Non unique.
+    pub title: String,
+    /// **description** is a text description of proposal. Non unique.
+    pub description: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]

--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -298,11 +298,11 @@ pub struct MsgIbcTransferResponse {
 #[serde(rename_all = "snake_case")]
 /// AdminProposal defines the struct for various proposals which Neutron's Admin Module may accept.
 pub enum AdminProposal {
-    /// **param_change_proposal** is a parameter change proposal field.
+    /// **ParamChangeProposal** is a parameter change proposal field.
     ParamChangeProposal(ParamChangeProposal),
-    /// **software_upgrade_proposal** is a software upgrade proposal field.
+    /// **SoftwareUpgradeProposal** is a software upgrade proposal field.
     SoftwareUpgradeProposal(SoftwareUpgradeProposal),
-    /// **cancel_software_upgrade_proposal** is a cancel software upgrade proposal field.
+    /// **CancelSoftwareUpgradeProposal** is a cancel software upgrade proposal field.
     CancelSoftwareUpgradeProposal(CancelSoftwareUpgradeProposal),
 }
 


### PR DESCRIPTION
implements software upgrade proposal field inside custom NeutronMsg -> AdminProposal

Part of [this task](https://p2pvalidator.atlassian.net/browse/NTRN-314)


https://github.com/neutron-org/neutron-tests/actions/runs/3908997608