### PR TITLE
chore: `InterchainQueries` → `NeutronQuery`

### DIFF
--- a/contracts/ibc_transfer/src/contract.rs
+++ b/contracts/ibc_transfer/src/contract.rs
@@ -3,9 +3,11 @@ use cosmwasm_std::{
     StdError, StdResult, SubMsg,
 };
 use cw2::set_contract_version;
-use neutron_sdk::bindings::query::InterchainQueries;
 use neutron_sdk::{
-    bindings::msg::{IbcFee, MsgIbcTransferResponse, NeutronMsg},
+    bindings::{
+        msg::{IbcFee, MsgIbcTransferResponse, NeutronMsg},
+        query::NeutronQuery,
+    },
     query::min_ibc_fee::query_min_ibc_fee,
     sudo::msg::{RequestPacket, RequestPacketTimeoutHeight, TransferSudoMsg},
     NeutronResult,
@@ -41,7 +43,7 @@ pub fn instantiate(
 
 #[entry_point]
 pub fn execute(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     env: Env,
     _: MessageInfo,
     msg: ExecuteMsg,
@@ -96,7 +98,7 @@ pub enum SudoPayload {
 
 // saves payload to process later to the storage and returns a SubmitTX Cosmos SubMsg with necessary reply id
 fn msg_with_sudo_callback<C: Into<CosmosMsg<T>>, T>(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     msg: C,
     payload: SudoPayload,
 ) -> StdResult<SubMsg<T>> {
@@ -138,7 +140,7 @@ pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> StdResult<Response> {
 }
 
 fn execute_send(
-    mut deps: DepsMut<InterchainQueries>,
+    mut deps: DepsMut<NeutronQuery>,
     env: Env,
     channel: String,
     to: String,

--- a/contracts/neutron_interchain_queries/src/contract.rs
+++ b/contracts/neutron_interchain_queries/src/contract.rs
@@ -9,7 +9,7 @@ use prost::Message as ProstMessage;
 use crate::msg::{ExecuteMsg, GetRecipientTxsResponse, InstantiateMsg, MigrateMsg, QueryMsg};
 use crate::state::{Transfer, RECIPIENT_TXS, TRANSFERS};
 use neutron_sdk::bindings::msg::NeutronMsg;
-use neutron_sdk::bindings::query::{InterchainQueries, QueryRegisteredQueryResponse};
+use neutron_sdk::bindings::query::{NeutronQuery, QueryRegisteredQueryResponse};
 use neutron_sdk::bindings::types::{Height, KVKey};
 use neutron_sdk::interchain_queries::queries::{
     get_registered_query, query_balance, query_bank_total, query_delegations,
@@ -51,7 +51,7 @@ pub fn instantiate(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    _deps: DepsMut<InterchainQueries>,
+    _deps: DepsMut<NeutronQuery>,
     _env: Env,
     _: MessageInfo,
     msg: ExecuteMsg,
@@ -207,7 +207,7 @@ pub fn remove_interchain_query(query_id: u64) -> NeutronResult<Response<NeutronM
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
+pub fn query(deps: Deps<NeutronQuery>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
     match msg {
         //TODO: check if query.result.height is too old (for all interchain queries)
         QueryMsg::Balance { query_id } => Ok(to_binary(&query_balance(deps, env, query_id)?)?),
@@ -233,7 +233,7 @@ pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronR
     }
 }
 
-fn query_recipient_txs(deps: Deps<InterchainQueries>, recipient: String) -> NeutronResult<Binary> {
+fn query_recipient_txs(deps: Deps<NeutronQuery>, recipient: String) -> NeutronResult<Binary> {
     let txs = RECIPIENT_TXS
         .load(deps.storage, &recipient)
         .unwrap_or_default();
@@ -247,7 +247,7 @@ pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> StdResult<Response
 }
 
 #[entry_point]
-pub fn sudo(deps: DepsMut<InterchainQueries>, env: Env, msg: SudoMsg) -> NeutronResult<Response> {
+pub fn sudo(deps: DepsMut<NeutronQuery>, env: Env, msg: SudoMsg) -> NeutronResult<Response> {
     match msg {
         // For handling tx query result
         SudoMsg::TxQueryResult {
@@ -265,7 +265,7 @@ pub fn sudo(deps: DepsMut<InterchainQueries>, env: Env, msg: SudoMsg) -> Neutron
 /// sudo_check_tx_query_result is an example callback for transaction query results that stores the
 /// deposits received as a result on the registered query in the contract's state.
 pub fn sudo_tx_query_result(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     _env: Env,
     query_id: u64,
     _height: Height,
@@ -383,7 +383,7 @@ fn check_deposits_size(deposits: &Vec<Transfer>) -> StdResult<()> {
 /// sudo_kv_query_result is the contract's callback for KV query results. Note that only the query
 /// id is provided, so you need to read the query result from the state.
 pub fn sudo_kv_query_result(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     _env: Env,
     query_id: u64,
 ) -> NeutronResult<Response> {

--- a/contracts/neutron_interchain_queries/src/testing/mock_querier.rs
+++ b/contracts/neutron_interchain_queries/src/testing/mock_querier.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use neutron_sdk::bindings::query::InterchainQueries;
+use neutron_sdk::bindings::query::NeutronQuery;
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 
@@ -22,7 +22,7 @@ impl CustomQuery for CustomQueryWrapper {}
 
 pub fn mock_dependencies(
     contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InterchainQueries> {
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, NeutronQuery> {
     let contract_addr = MOCK_CONTRACT_ADDR;
     let custom_querier: WasmMockQuerier =
         WasmMockQuerier::new(MockQuerier::new(&[(contract_addr, contract_balance)]));
@@ -36,14 +36,14 @@ pub fn mock_dependencies(
 }
 
 pub struct WasmMockQuerier {
-    base: MockQuerier<InterchainQueries>,
+    base: MockQuerier<NeutronQuery>,
     query_reponses: HashMap<u64, Binary>,
     registred_queries: HashMap<u64, Binary>,
 }
 
 impl Querier for WasmMockQuerier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult {
-        let request: QueryRequest<InterchainQueries> = match from_slice(bin_request) {
+        let request: QueryRequest<NeutronQuery> = match from_slice(bin_request) {
             Ok(v) => v,
             Err(e) => {
                 return QuerierResult::Err(SystemError::InvalidRequest {
@@ -57,26 +57,26 @@ impl Querier for WasmMockQuerier {
 }
 
 impl WasmMockQuerier {
-    pub fn handle_query(&self, request: &QueryRequest<InterchainQueries>) -> QuerierResult {
+    pub fn handle_query(&self, request: &QueryRequest<NeutronQuery>) -> QuerierResult {
         match &request {
-            QueryRequest::Custom(InterchainQueries::InterchainQueryResult { query_id }) => {
+            QueryRequest::Custom(NeutronQuery::InterchainQueryResult { query_id }) => {
                 SystemResult::Ok(ContractResult::Ok(
                     (*self.query_reponses.get(query_id).unwrap()).clone(),
                 ))
             }
-            QueryRequest::Custom(InterchainQueries::RegisteredInterchainQuery { query_id }) => {
+            QueryRequest::Custom(NeutronQuery::RegisteredInterchainQuery { query_id }) => {
                 SystemResult::Ok(ContractResult::Ok(
                     (*self.registred_queries.get(query_id).unwrap()).clone(),
                 ))
             }
-            QueryRequest::Custom(InterchainQueries::RegisteredInterchainQueries {
+            QueryRequest::Custom(NeutronQuery::RegisteredInterchainQueries {
                 owners: _owners,
                 connection_id: _connection_id,
                 pagination: _pagination,
             }) => {
                 todo!()
             }
-            QueryRequest::Custom(InterchainQueries::InterchainAccountAddress { .. }) => {
+            QueryRequest::Custom(NeutronQuery::InterchainAccountAddress { .. }) => {
                 todo!()
             }
             _ => self.base.handle_query(request),
@@ -111,7 +111,7 @@ pub struct TokenQuerier {
 }
 
 impl WasmMockQuerier {
-    pub fn new(base: MockQuerier<InterchainQueries>) -> Self {
+    pub fn new(base: MockQuerier<NeutronQuery>) -> Self {
         WasmMockQuerier {
             base,
             query_reponses: HashMap::new(),

--- a/contracts/neutron_interchain_queries/src/testing/tests.rs
+++ b/contracts/neutron_interchain_queries/src/testing/tests.rs
@@ -18,7 +18,7 @@ use cosmwasm_std::{
     StdError, Uint128,
 };
 use neutron_sdk::bindings::query::{
-    InterchainQueries, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse,
+    NeutronQuery, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse,
 };
 use neutron_sdk::bindings::types::{
     decode_hex, Height, InterchainQueryResult, KVKey, KVKeys, RegisteredQuery, StorageValue,
@@ -211,7 +211,7 @@ fn build_interchain_query_balance_response(addr: Addr, denom: String, amount: St
 
 // registers an interchain query
 fn register_query(
-    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier, InterchainQueries>,
+    deps: &mut OwnedDeps<MockStorage, MockApi, WasmMockQuerier, NeutronQuery>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -18,7 +18,7 @@ use neutron_sdk::bindings::msg::IbcFee;
 use neutron_sdk::{
     bindings::{
         msg::{MsgSubmitTxResponse, NeutronMsg},
-        query::{InterchainQueries, QueryInterchainAccountAddressResponse},
+        query::{NeutronQuery, QueryInterchainAccountAddressResponse},
         types::ProtobufAny,
     },
     interchain_txs::helpers::{
@@ -67,7 +67,7 @@ pub fn instantiate(
 
 #[entry_point]
 pub fn execute(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     env: Env,
     _: MessageInfo,
     msg: ExecuteMsg,
@@ -113,7 +113,7 @@ pub fn execute(
 }
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
+pub fn query(deps: Deps<NeutronQuery>, env: Env, msg: QueryMsg) -> NeutronResult<Binary> {
     match msg {
         QueryMsg::InterchainAccountAddress {
             interchain_account_id,
@@ -132,12 +132,12 @@ pub fn query(deps: Deps<InterchainQueries>, env: Env, msg: QueryMsg) -> NeutronR
 
 // returns ICA address from Neutron ICA SDK module
 pub fn query_interchain_address(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     connection_id: String,
 ) -> NeutronResult<Binary> {
-    let query = InterchainQueries::InterchainAccountAddress {
+    let query = NeutronQuery::InterchainAccountAddress {
         owner_address: env.contract.address.to_string(),
         interchain_account_id,
         connection_id,
@@ -149,7 +149,7 @@ pub fn query_interchain_address(
 
 // returns ICA address from the contract storage. The address was saved in sudo_open_ack method
 pub fn query_interchain_address_contract(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
 ) -> NeutronResult<Binary> {
@@ -158,7 +158,7 @@ pub fn query_interchain_address_contract(
 
 // returns the result
 pub fn query_acknowledgement_result(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     sequence_id: u64,
@@ -168,14 +168,14 @@ pub fn query_acknowledgement_result(
     Ok(to_binary(&res)?)
 }
 
-pub fn query_errors_queue(deps: Deps<InterchainQueries>) -> NeutronResult<Binary> {
+pub fn query_errors_queue(deps: Deps<NeutronQuery>) -> NeutronResult<Binary> {
     let res = read_errors_from_queue(deps.storage)?;
     Ok(to_binary(&res)?)
 }
 
 // saves payload to process later to the storage and returns a SubmitTX Cosmos SubMsg with necessary reply id
 fn msg_with_sudo_callback<C: Into<CosmosMsg<T>>, T>(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     msg: C,
     payload: SudoPayload,
 ) -> StdResult<SubMsg<T>> {
@@ -184,7 +184,7 @@ fn msg_with_sudo_callback<C: Into<CosmosMsg<T>>, T>(
 }
 
 fn execute_register_ica(
-    deps: DepsMut<InterchainQueries>,
+    deps: DepsMut<NeutronQuery>,
     env: Env,
     connection_id: String,
     interchain_account_id: String,
@@ -198,7 +198,7 @@ fn execute_register_ica(
 }
 
 fn execute_delegate(
-    mut deps: DepsMut<InterchainQueries>,
+    mut deps: DepsMut<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     validator: String,
@@ -257,7 +257,7 @@ fn execute_delegate(
 }
 
 fn execute_undelegate(
-    mut deps: DepsMut<InterchainQueries>,
+    mut deps: DepsMut<NeutronQuery>,
     env: Env,
     interchain_account_id: String,
     validator: String,

--- a/contracts/neutron_interchain_txs/src/testing/tests.rs
+++ b/contracts/neutron_interchain_txs/src/testing/tests.rs
@@ -11,9 +11,9 @@ use cosmwasm_std::{
     OwnedDeps,
 };
 
-use neutron_sdk::bindings::query::InterchainQueries;
+use neutron_sdk::bindings::query::NeutronQuery;
 
-pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, InterchainQueries> {
+pub fn mock_dependencies() -> OwnedDeps<MockStorage, MockApi, MockQuerier, NeutronQuery> {
     OwnedDeps {
         storage: MockStorage::default(),
         api: MockApi::default(),

--- a/packages/neutron-sdk/schema/neutron_query.json
+++ b/packages/neutron-sdk/schema/neutron_query.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "InterchainQueries",
+  "title": "NeutronQuery",
   "description": "The queries to interact with neutron specific blockchain modules.",
   "oneOf": [
     {

--- a/packages/neutron-sdk/src/bin/schema.rs
+++ b/packages/neutron-sdk/src/bin/schema.rs
@@ -2,8 +2,7 @@ use std::env::current_dir;
 use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
-use neutron_sdk::bindings::msg::NeutronMsg;
-use neutron_sdk::bindings::query::InterchainQueries;
+use neutron_sdk::bindings::{msg::NeutronMsg, query::NeutronQuery};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -11,5 +10,5 @@ fn main() {
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
     export_schema(&schema_for!(NeutronMsg), &out_dir);
-    export_schema(&schema_for!(InterchainQueries), &out_dir);
+    export_schema(&schema_for!(NeutronQuery), &out_dir);
 }

--- a/packages/neutron-sdk/src/bindings/query.rs
+++ b/packages/neutron-sdk/src/bindings/query.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 /// The queries to interact with neutron specific blockchain modules.
-pub enum InterchainQueries {
+pub enum NeutronQuery {
     /// Query a result of registered interchain query on remote chain
     InterchainQueryResult {
         /// **query_id** is an ID registered interchain query
@@ -97,4 +97,4 @@ pub struct QueryInterchainAccountAddressResponse {
     pub interchain_account_address: String,
 }
 
-impl CustomQuery for InterchainQueries {}
+impl CustomQuery for NeutronQuery {}

--- a/packages/neutron-sdk/src/interchain_queries/queries.rs
+++ b/packages/neutron-sdk/src/interchain_queries/queries.rs
@@ -1,5 +1,5 @@
 use crate::bindings::query::{
-    InterchainQueries, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse,
+    NeutronQuery, QueryRegisteredQueryResponse, QueryRegisteredQueryResultResponse,
 };
 use crate::interchain_queries::types::{
     Balances, Delegations, FeePool, GovernmentProposal, KVReconstruct, QueryType, StakingValidator,
@@ -65,10 +65,10 @@ pub fn check_query_type(actual: QueryType, expected: QueryType) -> NeutronResult
 
 /// Queries registered query info
 pub fn get_registered_query(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     interchain_query_id: u64,
 ) -> NeutronResult<QueryRegisteredQueryResponse> {
-    let query = InterchainQueries::RegisteredInterchainQuery {
+    let query = NeutronQuery::RegisteredInterchainQuery {
         query_id: interchain_query_id,
     };
 
@@ -78,10 +78,10 @@ pub fn get_registered_query(
 
 /// Queries interchain query result (raw KV storage values or transactions) from Interchain Queries Module
 fn get_interchain_query_result(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     interchain_query_id: u64,
 ) -> NeutronResult<QueryRegisteredQueryResultResponse> {
-    let interchain_query = InterchainQueries::InterchainQueryResult {
+    let interchain_query = NeutronQuery::InterchainQueryResult {
         query_id: interchain_query_id,
     };
     let res = deps.querier.query(&interchain_query.into())?;
@@ -90,7 +90,7 @@ fn get_interchain_query_result(
 
 /// Reads submitted raw KV values for Interchain Query with **query_id** from the storage and reconstructs the result
 pub fn query_kv_result<T: KVReconstruct>(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     query_id: u64,
 ) -> NeutronResult<T> {
     let registered_query_result = get_interchain_query_result(deps, query_id)?;
@@ -101,7 +101,7 @@ pub fn query_kv_result<T: KVReconstruct>(
 /// Returns balance of account on remote chain for particular denom
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_balance(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<BalanceResponse> {
@@ -122,7 +122,7 @@ pub fn query_balance(
 /// Returns bank total supply on remote chain for particular denom
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_bank_total(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<TotalSupplyResponse> {
@@ -143,7 +143,7 @@ pub fn query_bank_total(
 /// Returns distribution fee pool on remote chain
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_distribution_fee_pool(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<FeePoolResponse> {
@@ -164,7 +164,7 @@ pub fn query_distribution_fee_pool(
 /// Returns staking validator from remote chain
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_staking_validators(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<ValidatorResponse> {
@@ -185,7 +185,7 @@ pub fn query_staking_validators(
 /// Returns list of government proposals on the remote chain
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_government_proposals(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<ProposalResponse> {
@@ -206,7 +206,7 @@ pub fn query_government_proposals(
 /// Returns delegations of particular delegator on remote chain
 /// * ***registered_query_id*** is an identifier of the corresponding registered interchain query
 pub fn query_delegations(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
     _env: Env,
     registered_query_id: u64,
 ) -> NeutronResult<DelegatorDelegationsResponse> {

--- a/packages/neutron-sdk/src/interchain_queries/register_queries.rs
+++ b/packages/neutron-sdk/src/interchain_queries/register_queries.rs
@@ -1,4 +1,4 @@
-use crate::bindings::query::InterchainQueries;
+use crate::bindings::query::NeutronQuery;
 use crate::interchain_queries::types::{
     QueryType, TransactionFilterItem, TransactionFilterOp, TransactionFilterValue, BANK_STORE_KEY,
     DISTRIBUTION_STORE_KEY, GOV_STORE_KEY, HEIGHT_FIELD, KEY_BOND_DENOM, PARAMS_STORE_KEY,
@@ -21,7 +21,7 @@ use cosmwasm_std::{Binary, DepsMut, Env};
 #[allow(clippy::too_many_arguments)]
 /// Creates a message to register an Interchain Query with provided params
 pub fn new_register_interchain_query_msg(
-    _deps: DepsMut<InterchainQueries>,
+    _deps: DepsMut<NeutronQuery>,
     _env: Env,
     connection_id: String,
     query_type: QueryType,

--- a/packages/neutron-sdk/src/query/min_ibc_fee.rs
+++ b/packages/neutron-sdk/src/query/min_ibc_fee.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bindings::{msg::IbcFee, query::InterchainQueries},
+    bindings::{msg::IbcFee, query::NeutronQuery},
     NeutronResult,
 };
 use cosmwasm_std::Deps;
@@ -12,7 +12,7 @@ pub struct MinIbcFeeResponse {
     pub min_fee: IbcFee,
 }
 
-pub fn query_min_ibc_fee(deps: Deps<InterchainQueries>) -> NeutronResult<MinIbcFeeResponse> {
-    let query = InterchainQueries::MinIbcFee {};
+pub fn query_min_ibc_fee(deps: Deps<NeutronQuery>) -> NeutronResult<MinIbcFeeResponse> {
+    let query = NeutronQuery::MinIbcFee {};
     Ok(deps.querier.query(&query.into())?)
 }

--- a/packages/neutron-sdk/src/query/total_burned_neutrons.rs
+++ b/packages/neutron-sdk/src/query/total_burned_neutrons.rs
@@ -1,4 +1,4 @@
-use crate::{bindings::query::InterchainQueries, NeutronResult};
+use crate::{bindings::query::NeutronQuery, NeutronResult};
 use cosmwasm_std::{Coin, Deps};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -11,8 +11,8 @@ pub struct TotalBurnedNeutronsAmountResponse {
 
 /// Returns total amount of burned neutron fees
 pub fn query_total_burned_neutrons(
-    deps: Deps<InterchainQueries>,
+    deps: Deps<NeutronQuery>,
 ) -> NeutronResult<TotalBurnedNeutronsAmountResponse> {
-    let query = InterchainQueries::TotalBurnedNeutronsAmount {};
+    let query = NeutronQuery::TotalBurnedNeutronsAmount {};
     Ok(deps.querier.query(&query.into())?)
 }


### PR DESCRIPTION
This PR is safe to merge since it only renames one enum, and this rename doesn't even affect serialization results.

On top of that, currently, contracts which depend on neutron-sdk, must update neutron SDK version in their Cargo.toml in order to use new changes, so merging this PR wouldn't break any of existing contracts.

Merge with:
- https://github.com/neutron-org/neutron-docs/pull/69