### PR TITLE
Add query for proposal voters

### DIFF
--- a/contracts/neutron_interchain_queries/src/contract.rs
+++ b/contracts/neutron_interchain_queries/src/contract.rs
@@ -22,16 +22,22 @@ use neutron_sdk::interchain_queries::v047::queries::{
 };
 use neutron_sdk::interchain_queries::{
     check_query_type, get_registered_query, query_kv_result,
-    v047::{
-        register_queries::{
-            new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
-            new_register_delegator_delegations_query_msg,
-            new_register_delegator_unbonding_delegations_query_msg,
-            new_register_distribution_fee_pool_query_msg, new_register_gov_proposal_query_msg,
-            new_register_staking_validators_query_msg, new_register_transfers_query_msg,
-            new_register_wasm_contract_store_query_msg,
-        },
+    v045::{
+        new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
+        new_register_delegator_delegations_query_msg,
+        new_register_delegator_unbonding_delegations_query_msg,
+        new_register_distribution_fee_pool_query_msg, new_register_gov_proposals_query_msg,
+        new_register_staking_validators_query_msg, new_register_transfers_query_msg,
+        register_queries::new_register_wasm_contract_store_query_msg,
         types::{COSMOS_SDK_TRANSFER_MSG_URL, RECIPIENT_FIELD},
+    },
+    v047::register_queries::{
+        new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
+        new_register_delegator_delegations_query_msg,
+        new_register_delegator_unbonding_delegations_query_msg,
+        new_register_distribution_fee_pool_query_msg, new_register_gov_proposal_query_msg,
+        new_register_staking_validators_query_msg, new_register_transfers_query_msg,
+        new_register_wasm_contract_store_query_msg,
     },
 };
 use neutron_sdk::sudo::msg::SudoMsg;
@@ -178,7 +184,7 @@ pub fn register_gov_proposal_query(
     proposals_ids: Vec<u64>,
     update_period: u64,
 ) -> NeutronResult<Response<NeutronMsg>> {
-    let msg = new_register_gov_proposal_query_msg(connection_id, proposals_ids, update_period)?;
+    let msg = new_register_gov_proposals_query_msg(connection_id, proposals_ids, update_period)?;
 
     Ok(Response::new().add_message(msg))
 }

--- a/contracts/neutron_interchain_queries/src/contract.rs
+++ b/contracts/neutron_interchain_queries/src/contract.rs
@@ -22,22 +22,16 @@ use neutron_sdk::interchain_queries::v047::queries::{
 };
 use neutron_sdk::interchain_queries::{
     check_query_type, get_registered_query, query_kv_result,
-    v045::{
-        new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
-        new_register_delegator_delegations_query_msg,
-        new_register_delegator_unbonding_delegations_query_msg,
-        new_register_distribution_fee_pool_query_msg, new_register_gov_proposals_query_msg,
-        new_register_staking_validators_query_msg, new_register_transfers_query_msg,
-        register_queries::new_register_wasm_contract_store_query_msg,
+    v047::{
+        register_queries::{
+            new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
+            new_register_delegator_delegations_query_msg,
+            new_register_delegator_unbonding_delegations_query_msg,
+            new_register_distribution_fee_pool_query_msg, new_register_gov_proposals_query_msg,
+            new_register_staking_validators_query_msg, new_register_transfers_query_msg,
+            new_register_wasm_contract_store_query_msg,
+        },
         types::{COSMOS_SDK_TRANSFER_MSG_URL, RECIPIENT_FIELD},
-    },
-    v047::register_queries::{
-        new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
-        new_register_delegator_delegations_query_msg,
-        new_register_delegator_unbonding_delegations_query_msg,
-        new_register_distribution_fee_pool_query_msg, new_register_gov_proposal_query_msg,
-        new_register_staking_validators_query_msg, new_register_transfers_query_msg,
-        new_register_wasm_contract_store_query_msg,
     },
 };
 use neutron_sdk::sudo::msg::SudoMsg;

--- a/contracts/neutron_interchain_queries/src/testing/tests.rs
+++ b/contracts/neutron_interchain_queries/src/testing/tests.rs
@@ -439,10 +439,10 @@ fn test_gov_proposals_query() {
                         voting_end_time: None,
                         voting_start_time: None,
                         final_tally_result: Some(TallyResult {
-                            abstain: "0".to_string(),
-                            yes: "0".to_string(),
-                            no: "0".to_string(),
-                            no_with_veto: "0".to_string(),
+                            abstain: Uint128::zero(),
+                            yes: Uint128::zero(),
+                            no: Uint128::zero(),
+                            no_with_veto: Uint128::zero(),
                         }),
                     },
                     Proposal {
@@ -458,10 +458,10 @@ fn test_gov_proposals_query() {
                         voting_end_time: None,
                         voting_start_time: None,
                         final_tally_result: Some(TallyResult {
-                            abstain: "0".to_string(),
-                            yes: "0".to_string(),
-                            no: "0".to_string(),
-                            no_with_veto: "0".to_string(),
+                            abstain: Uint128::zero(),
+                            yes: Uint128::zero(),
+                            no: Uint128::zero(),
+                            no_with_veto: Uint128::zero(),
                         }),
                     },
                     Proposal {
@@ -477,10 +477,10 @@ fn test_gov_proposals_query() {
                         voting_end_time: None,
                         voting_start_time: None,
                         final_tally_result: Some(TallyResult {
-                            abstain: "0".to_string(),
-                            yes: "0".to_string(),
-                            no: "0".to_string(),
-                            no_with_veto: "0".to_string(),
+                            abstain: Uint128::zero(),
+                            yes: Uint128::zero(),
+                            no: Uint128::zero(),
+                            no_with_veto: Uint128::zero(),
                         }),
                     },
                 ]

--- a/packages/neutron-sdk/src/interchain_queries/v045/mod.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/mod.rs
@@ -7,7 +7,7 @@ pub use register_queries::{
     new_register_balance_query_msg, new_register_bank_total_supply_query_msg,
     new_register_delegator_delegations_query_msg,
     new_register_delegator_unbonding_delegations_query_msg,
-    new_register_distribution_fee_pool_query_msg, new_register_gov_proposal_query_msg,
+    new_register_distribution_fee_pool_query_msg, new_register_gov_proposals_query_msg,
     new_register_staking_validators_query_msg, new_register_transfers_query_msg,
 };
 

--- a/packages/neutron-sdk/src/interchain_queries/v045/register_queries.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/register_queries.rs
@@ -2,8 +2,8 @@ use crate::interchain_queries::types::{
     QueryPayload, TransactionFilterItem, TransactionFilterOp, TransactionFilterValue,
 };
 use crate::interchain_queries::v045::types::{
-    BANK_STORE_KEY, DISTRIBUTION_STORE_KEY, GOV_STORE_KEY, HEIGHT_FIELD, KEY_BOND_DENOM,
-    PARAMS_STORE_KEY, RECIPIENT_FIELD, STAKING_STORE_KEY, WASM_STORE_KEY,
+    BANK_STORE_KEY, DISTRIBUTION_STORE_KEY, HEIGHT_FIELD, KEY_BOND_DENOM, PARAMS_STORE_KEY,
+    RECIPIENT_FIELD, SLASHING_STORE_KEY, STAKING_STORE_KEY, WASM_STORE_KEY,
 };
 use crate::{
     bindings::{msg::NeutronMsg, types::KVKey},
@@ -11,14 +11,12 @@ use crate::{
     interchain_queries::helpers::decode_and_convert,
     interchain_queries::v045::helpers::{
         create_account_denom_balance_key, create_delegation_key, create_fee_pool_key,
-        create_gov_proposal_key, create_params_store_key, create_total_denom_key,
-        create_unbonding_delegation_key, create_validator_key, create_wasm_contract_store_key,
+        create_gov_proposal_keys, create_gov_proposals_voters_votes_keys, create_params_store_key,
+        create_total_denom_key, create_unbonding_delegation_key, create_validator_key,
+        create_validator_signing_info_key, create_wasm_contract_store_key,
     },
 };
 use cosmwasm_std::Binary;
-
-use super::helpers::create_validator_signing_info_key;
-use super::types::SLASHING_STORE_KEY;
 
 /// Creates a message to register an Interchain Query to get balance of account on remote chain for particular denom
 ///
@@ -94,28 +92,68 @@ pub fn new_register_distribution_fee_pool_query_msg(
     )
 }
 
-/// Creates a message to register an Interchain Query to get governance proposal on remote chain
+/// Creates a message to register an Interchain Query to get governance proposals on remote chain
 ///
 /// * **connection_id** is an IBC connection identifier between Neutron and remote chain;
-/// * **proposal_id** is a proposal id from remote chain.
+/// * **proposals_ids** is a list of proposals ids from remote chain.
 /// * **update_period** is used to say how often the query must be updated.
-pub fn new_register_gov_proposal_query_msg(
+pub fn new_register_gov_proposals_query_msg(
     connection_id: String,
     proposals_ids: Vec<u64>,
     update_period: u64,
 ) -> NeutronResult<NeutronMsg> {
-    let mut kv_keys: Vec<KVKey> = Vec::with_capacity(proposals_ids.len());
-
-    for id in proposals_ids {
-        let kv_key = KVKey {
-            path: GOV_STORE_KEY.to_string(),
-            key: Binary(create_gov_proposal_key(id)?),
-        };
-
-        kv_keys.push(kv_key)
-    }
+    let kv_keys = create_gov_proposal_keys(proposals_ids)?;
 
     NeutronMsg::register_interchain_query(QueryPayload::KV(kv_keys), connection_id, update_period)
+}
+
+/// Creates a message to update an Interchain Query to get governance proposals on remote chain
+///
+/// * **query_id** is an IBC connection identifier between Neutron and remote chain;
+/// * **proposals_ids** is a list of proposals ids from remote chain.
+/// * **new_update_period** is used to update period of how often the query must be updated.
+pub fn update_gov_proposals_query_msg(
+    query_id: u64,
+    proposals_ids: Vec<u64>,
+    new_update_period: Option<u64>,
+) -> NeutronResult<NeutronMsg> {
+    let kv_keys = create_gov_proposal_keys(proposals_ids)?;
+
+    NeutronMsg::update_interchain_query(query_id, Some(kv_keys), new_update_period, None)
+}
+
+/// Creates a message to register an Interchain Query to get governance proposals votes on the remote chain
+///
+/// * **connection_id** is an IBC connection identifier between Neutron and remote chain;
+/// * **proposals_ids** is a list of proposals ids from remote chain.
+/// * **voters** is a list of voter to get voting info from remote chain.
+/// * **update_period** is used to say how often the query must be updated.
+pub fn new_register_gov_proposals_voters_votes_query_msg(
+    connection_id: String,
+    proposals_ids: Vec<u64>,
+    voters: Vec<String>,
+    update_period: u64,
+) -> NeutronResult<NeutronMsg> {
+    let kv_keys = create_gov_proposals_voters_votes_keys(proposals_ids, voters)?;
+
+    NeutronMsg::register_interchain_query(QueryPayload::KV(kv_keys), connection_id, update_period)
+}
+
+/// Creates a message to update an Interchain Query to get governance proposals votes on the remote chain
+///
+/// * **query_id** is an IBC connection identifier between Neutron and remote chain;
+/// * **proposals_ids** is a list of proposals ids from remote chain.
+/// * **voters** is a list of voter to get voting info from remote chain.
+/// * **new_update_period** is used to update period of how often the query must be updated.
+pub fn update_gov_proposals_votes_query_msg(
+    query_id: u64,
+    proposals_ids: Vec<u64>,
+    voters: Vec<String>,
+    new_update_period: Option<u64>,
+) -> NeutronResult<NeutronMsg> {
+    let kv_keys = create_gov_proposals_voters_votes_keys(proposals_ids, voters)?;
+
+    NeutronMsg::update_interchain_query(query_id, Some(kv_keys), new_update_period, None)
 }
 
 /// Creates a message to register an Interchain Query to get validator info on remote chain

--- a/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
@@ -3,15 +3,16 @@ use crate::interchain_queries::helpers::decode_and_convert;
 use crate::interchain_queries::types::{AddressBytes, KVReconstruct};
 use crate::interchain_queries::v045::helpers::{
     create_account_denom_balance_key, create_delegation_key, create_fee_pool_key,
-    create_gov_proposal_key, create_params_store_key, create_total_denom_key, create_validator_key,
-    create_validator_signing_info_key, deconstruct_account_denom_balance_key,
+    create_gov_proposal_key, create_gov_proposal_votes_key, create_params_store_key,
+    create_total_denom_key, create_validator_key, create_validator_signing_info_key,
+    deconstruct_account_denom_balance_key,
 };
 use crate::interchain_queries::v045::types::BALANCES_PREFIX;
 use crate::interchain_queries::v045::types::{
-    Balances, Delegations, FeePool, GovernmentProposal, Proposal, SigningInfo, StakingValidator,
-    TallyResult, TotalSupply, UnbondingDelegations, UnbondingEntry, UnbondingResponse,
-    Validator as ContractValidator, ValidatorSigningInfo, DECIMAL_PLACES, KEY_BOND_DENOM,
-    STAKING_STORE_KEY,
+    Balances, Delegations, FeePool, GovernmentProposal, GovernmentProposalVotes, Proposal,
+    ProposalVote, SigningInfo, StakingValidator, TallyResult, TotalSupply, UnbondingDelegations,
+    UnbondingEntry, UnbondingResponse, Validator as ContractValidator, ValidatorSigningInfo,
+    WeightedVoteOption, DECIMAL_PLACES, KEY_BOND_DENOM, STAKING_STORE_KEY,
 };
 use crate::{NeutronError, NeutronResult};
 use base64::prelude::*;
@@ -19,7 +20,8 @@ use base64::Engine;
 use cosmos_sdk_proto::cosmos::base::v1beta1::{Coin, DecCoin};
 use cosmos_sdk_proto::cosmos::distribution::v1beta1::FeePool as CosmosFeePool;
 use cosmos_sdk_proto::cosmos::gov::v1beta1::{
-    Proposal as CosmosProposal, TallyResult as CosmosTallyResult,
+    Proposal as CosmosProposal, TallyResult as CosmosTallyResult, Vote,
+    WeightedVoteOption as CosmosWeightedVoteOption,
 };
 use cosmos_sdk_proto::cosmos::slashing::v1beta1::ValidatorSigningInfo as CosmosValidatorSigningInfo;
 use cosmos_sdk_proto::cosmos::staking::v1beta1::{
@@ -40,6 +42,7 @@ pub const TOTAL_SUPPLY_HEX_RESPONSE: &str = "333030303031303938";
 pub const FEE_POOL_HEX_RESPONSE: &str =
     "0a1d0a057374616b6512143231393630303030303030303030303030303030";
 pub const GOV_PROPOSAL_HEX_RESPONSE: &str = "0801129f010a202f636f736d6f732e676f762e763162657461312e5465787450726f706f73616c127b0a11416464204e65772056616c696461746f721266546869732070726f706f73616c20726571756573747320616464696e672061206e65772076616c696461746f7220746f20746865206e6574776f726b20746f20696d70726f766520646563656e7472616c697a6174696f6e20616e642073656375726974792e1801220c0a01301201301a01302201302a0c08c9fdd3a20610988990d103320c08c9c3dea20610988990d1033a0d0a057374616b65120431303030420b088092b8c398feffffff014a0b088092b8c398feffffff01";
+pub const GOV_PROPOSAL_VOTES_HEX_RESPONSE: &str = "0804122d636f736d6f73313068397374633576366e7467657967663578663934356e6a717135683332723533757175767722170801121331303030303030303030303030303030303030";
 pub const STAKING_DENOM_HEX_RESPONSE: &str = "227374616b6522";
 pub const STAKING_VALIDATOR_HEX_RESPONSE: &str = "0a34636f736d6f7376616c6f706572313566716a706a39307275686a353771336c366135686461307274373767366d63656b326d747112430a1d2f636f736d6f732e63727970746f2e656432353531392e5075624b657912220a20b20c07b3eb900df72b48c24e9a2e06ff4fe73bbd255e433af8eae3b1988e698820032a09313030303030303030321b3130303030303030303030303030303030303030303030303030303a080a066d796e6f64654a00524a0a3b0a1231303030303030303030303030303030303012123230303030303030303030303030303030301a113130303030303030303030303030303030120b089cfcd3a20610e0dc890b5a0131";
 pub const DELEGATOR_DELEGATIONS_HEX_RESPONSE: &str = "0a2d636f736d6f73313566716a706a39307275686a353771336c366135686461307274373767366d63757a3777386e1234636f736d6f7376616c6f706572313566716a706a39307275686a353771336c366135686461307274373767366d63656b326d74711a1b313030303030303030303030303030303030303030303030303030";
@@ -580,10 +583,10 @@ fn test_government_proposals_reconstruct() {
                     voting_start_time: Some(4444444),
                     voting_end_time: Some(555555555),
                     final_tally_result: Some(TallyResult {
-                        abstain: "1".to_string(),
-                        no: "2".to_string(),
-                        no_with_veto: "3".to_string(),
-                        yes: "4".to_string(),
+                        abstain: Uint128::from(1u64),
+                        no: Uint128::from(2u64),
+                        no_with_veto: Uint128::from(3u64),
+                        yes: Uint128::from(4u64),
                     }),
                 }],
             }),
@@ -674,6 +677,105 @@ fn test_government_proposals_reconstruct() {
         let gov_proposal = GovernmentProposal::reconstruct(&st_values);
 
         assert_eq!(gov_proposal, ts.expected_result)
+    }
+}
+
+#[allow(deprecated)]
+#[test]
+fn test_proposal_votes_reconstruct() {
+    struct TestCase {
+        proposal_votes: Vec<Vote>,
+        expected_result: NeutronResult<GovernmentProposalVotes>,
+    }
+
+    let test_cases: Vec<TestCase> = vec![
+        TestCase {
+            proposal_votes: vec![Vote {
+                proposal_id: 1,
+                voter: "cosmos1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                option: 0,
+                options: vec![CosmosWeightedVoteOption {
+                    weight: "1000000000000000000".to_string(),
+                    option: 1,
+                }],
+            }],
+            expected_result: Ok(GovernmentProposalVotes {
+                proposal_votes: vec![ProposalVote {
+                    proposal_id: 1,
+                    voter: "cosmos1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                    options: vec![WeightedVoteOption {
+                        weight: "1000000000000000000".to_string(),
+                        option: 1,
+                    }],
+                }],
+            }),
+        },
+        TestCase {
+            proposal_votes: vec![
+                Vote {
+                    proposal_id: 1,
+                    voter: "cosmos1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                    option: 0,
+                    options: vec![CosmosWeightedVoteOption {
+                        weight: "1000000000000000000".to_string(),
+                        option: 1,
+                    }],
+                },
+                Vote {
+                    proposal_id: 2,
+                    voter: "osmo1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                    option: 0,
+                    options: vec![CosmosWeightedVoteOption {
+                        weight: "567890".to_string(),
+                        option: 2,
+                    }],
+                },
+            ],
+            expected_result: Ok(GovernmentProposalVotes {
+                proposal_votes: vec![
+                    ProposalVote {
+                        proposal_id: 1,
+                        voter: "cosmos1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                        options: vec![WeightedVoteOption {
+                            weight: "1000000000000000000".to_string(),
+                            option: 1,
+                        }],
+                    },
+                    ProposalVote {
+                        proposal_id: 2,
+                        voter: "osmo1yz54ncxj9csp7un3xled03q6thrrhy9cztkfzs".to_string(),
+                        options: vec![WeightedVoteOption {
+                            weight: "567890".to_string(),
+                            option: 2,
+                        }],
+                    },
+                ],
+            }),
+        },
+        TestCase {
+            proposal_votes: vec![],
+            expected_result: Ok(GovernmentProposalVotes {
+                proposal_votes: vec![],
+            }),
+        },
+    ];
+
+    for ts in test_cases {
+        let mut st_values: Vec<StorageValue> = vec![];
+
+        for votes in &ts.proposal_votes {
+            let proposal_key = create_gov_proposal_votes_key(votes.proposal_id).unwrap();
+            let s = StorageValue {
+                storage_prefix: "".to_string(),
+                key: Binary(proposal_key),
+                value: Binary(votes.encode_to_vec()),
+            };
+            st_values.push(s);
+        }
+
+        let gov_proposals_votes = GovernmentProposalVotes::reconstruct(&st_values);
+
+        assert_eq!(gov_proposals_votes, ts.expected_result)
     }
 }
 
@@ -1045,6 +1147,32 @@ fn test_government_proposals_reconstruct_from_hex() {
                     no_with_veto: String::from("0"),
                 }),
             }]
+        }
+    );
+}
+
+#[test]
+fn test_proposal_votes_reconstruct_from_hex() {
+    let bytes = hex::decode(GOV_PROPOSAL_VOTES_HEX_RESPONSE).unwrap(); // decode hex string to bytes
+    let base64_input = BASE64_STANDARD.encode(bytes); // encode bytes to base64 string
+
+    let s = StorageValue {
+        storage_prefix: String::default(), // not used in reconstruct
+        key: Binary::default(),            // not used in reconstruct
+        value: Binary::from_base64(base64_input.as_str()).unwrap(),
+    };
+    let votes = GovernmentProposalVotes::reconstruct(&[s]).unwrap();
+    assert_eq!(
+        votes,
+        GovernmentProposalVotes {
+            proposal_votes: vec![ProposalVote {
+                proposal_id: 4,
+                voter: "cosmos10h9stc5v6ntgeygf5xf945njqq5h32r53uquvw".to_string(),
+                options: vec![WeightedVoteOption {
+                    weight: "1000000000000000000".to_string(),
+                    option: 1,
+                }],
+            }],
         }
     );
 }

--- a/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
@@ -1141,10 +1141,10 @@ fn test_government_proposals_reconstruct_from_hex() {
                 voting_start_time: Some(18446744011573954816u64), // 0001-01-01T00:00:00Z
                 voting_end_time: Some(18446744011573954816u64), // 0001-01-01T00:00:00Z
                 final_tally_result: Some(TallyResult {
-                    yes: String::from("0"),
-                    no: String::from("0"),
-                    abstain: String::from("0"),
-                    no_with_veto: String::from("0"),
+                    yes: Uint128::zero(),
+                    no: Uint128::zero(),
+                    abstain: Uint128::zero(),
+                    no_with_veto: Uint128::zero(),
                 }),
             }]
         }

--- a/packages/neutron-sdk/src/interchain_queries/v045/types.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/types.rs
@@ -4,6 +4,7 @@ use crate::{
     bindings::types::StorageValue,
     errors::error::{NeutronError, NeutronResult},
 };
+use cosmos_sdk_proto::cosmos::gov::v1beta1::Vote;
 use cosmos_sdk_proto::cosmos::{
     base::v1beta1::Coin as CosmosCoin,
     distribution::v1beta1::FeePool as CosmosFeePool,
@@ -59,6 +60,10 @@ pub const FEE_POOL_KEY: u8 = 0x00;
 /// Key for Proposals in the **gov** module's storage
 /// <https://github.com/cosmos/cosmos-sdk/blob/35ae2c4c72d4aeb33447d5a7af23ca47f786606e/x/gov/types/keys.go#L41>
 pub const PROPOSALS_KEY_PREFIX: u8 = 0x00;
+
+/// Key for Votes in the **gov** module's storage
+/// <https://github.com/cosmos/cosmos-sdk/blob/35ae2c4c72d4aeb33447d5a7af23ca47f786606e/x/gov/types/keys.go#L48>
+pub const VOTES_KEY_PREFIX: u8 = 0x20;
 
 /// Key for Wasm Contract Store in the **wasm** module's storage
 /// <https://github.com/CosmWasm/wasmd/blob/e6d451bf9dd96a555b10e72aa3c0f6b820d34684/x/wasm/types/keys.go#L28>
@@ -312,10 +317,10 @@ impl KVReconstruct for SigningInfo {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 /// TallyResult defines a standard tally for a governance proposal.
 pub struct TallyResult {
-    pub yes: String,
-    pub no: String,
-    pub abstain: String,
-    pub no_with_veto: String,
+    pub yes: Uint128,
+    pub no: Uint128,
+    pub abstain: Uint128,
+    pub no_with_veto: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
@@ -365,10 +370,11 @@ impl KVReconstruct for GovernmentProposal {
                 voting_end_time: proposal.voting_end_time.map(|v| v.seconds as u64),
                 voting_start_time: proposal.voting_start_time.map(|v| v.seconds as u64),
                 final_tally_result: final_tally_result.as_ref().map(|v| TallyResult {
-                    abstain: v.abstain.to_string(),
-                    no: v.no.to_string(),
-                    no_with_veto: v.no_with_veto.to_string(),
-                    yes: v.yes.to_string(),
+                    abstain: Uint128::from_str(v.abstain.as_str()).unwrap_or(Uint128::zero()),
+                    no: Uint128::from_str(v.no.as_str()).unwrap_or(Uint128::zero()),
+                    no_with_veto: Uint128::from_str(v.no_with_veto.as_str())
+                        .unwrap_or(Uint128::zero()),
+                    yes: Uint128::from_str(v.yes.as_str()).unwrap_or(Uint128::zero()),
                 }),
             };
 
@@ -376,6 +382,54 @@ impl KVReconstruct for GovernmentProposal {
         }
 
         Ok(GovernmentProposal { proposals })
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+/// Proposal vote option defines the members of a governance proposal vote option.
+pub struct WeightedVoteOption {
+    pub option: i32,
+    pub weight: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+/// Proposal vote defines the core field members of a governance proposal votes.
+pub struct ProposalVote {
+    pub proposal_id: u64,
+    pub voter: String,
+    pub options: Vec<WeightedVoteOption>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+/// A structure that can be reconstructed from **StorageValues**'s for the **Government Proposal Votes Interchain Query**.
+pub struct GovernmentProposalVotes {
+    pub proposal_votes: Vec<ProposalVote>,
+}
+
+impl KVReconstruct for GovernmentProposalVotes {
+    fn reconstruct(storage_values: &[StorageValue]) -> NeutronResult<GovernmentProposalVotes> {
+        let mut proposal_votes = Vec::with_capacity(storage_values.len());
+
+        for kv in storage_values {
+            let voter_vote: Vote = Vote::decode(kv.value.as_slice())?;
+
+            let vote = ProposalVote {
+                proposal_id: voter_vote.proposal_id,
+                voter: voter_vote.voter,
+                options: voter_vote
+                    .options
+                    .into_iter()
+                    .map(|v| WeightedVoteOption {
+                        option: v.option,
+                        weight: v.weight,
+                    })
+                    .collect(),
+            };
+
+            proposal_votes.push(vote);
+        }
+
+        Ok(GovernmentProposalVotes { proposal_votes })
     }
 }
 

--- a/packages/neutron-sdk/src/interchain_queries/v047/testing.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v047/testing.rs
@@ -581,10 +581,10 @@ fn test_government_proposals_reconstruct() {
                     voting_start_time: Some(4444444),
                     voting_end_time: Some(555555555),
                     final_tally_result: Some(TallyResult {
-                        abstain: "1".to_string(),
-                        no: "2".to_string(),
-                        no_with_veto: "3".to_string(),
-                        yes: "4".to_string(),
+                        abstain: Uint128::from(1u128),
+                        no: Uint128::from(2u128),
+                        no_with_veto: Uint128::from(3u128),
+                        yes: Uint128::from(4u128),
                     }),
                 }],
             }),
@@ -1148,10 +1148,10 @@ fn test_government_proposals_reconstruct_from_hex() {
                 voting_start_time: Some(1553114639u64), // 0001-01-01T00:00:00Z
                 voting_end_time: Some(1554324239u64),   // 0001-01-01T00:00:00Z
                 final_tally_result: Some(TallyResult {
-                    yes: String::from("97118903526799"),
-                    no: String::from("320545400000"),
-                    abstain: String::from("402380577234"),
-                    no_with_veto: String::from("0"),
+                    yes: Uint128::from(97118903526799u128),
+                    no: Uint128::from(320545400000u128),
+                    abstain: Uint128::from(402380577234u128),
+                    no_with_veto: Uint128::zero(),
                 }),
             }]
         }


### PR DESCRIPTION
This PR will add support for queries of the proposal voting process. It will let to query votes per voter and per proposal.

Related PRs:
1. [Dev Contracts](https://github.com/neutron-org/neutron-dev-contracts/pull/40)
2. [Integration Tests](https://github.com/neutron-org/neutron-integration-tests/pull/265)
