### PR TITLE
Remove usage of deprecated `data` field in Neutron SDK ICTX helper for SDK 0.47 chains & update SDK 0.45 helper to backw compat NTRN-223

### DIFF
--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -19,12 +19,8 @@ use neutron_sdk::{
         query::{NeutronQuery, QueryInterchainAccountAddressResponse},
         types::ProtobufAny,
     },
-    interchain_txs::helpers::{
-         decode_message_response, get_port_id,
-    },
-    interchain_txs::v047::helpers::{
-        decode_acknowledgement_response
-    },
+    interchain_txs::helpers::{decode_message_response, get_port_id},
+    interchain_txs::v047::helpers::decode_acknowledgement_response,
     query::min_ibc_fee::query_min_ibc_fee,
     sudo::msg::{RequestPacket, SudoMsg},
     NeutronError, NeutronResult,

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -19,7 +19,7 @@ use neutron_sdk::{
         query::{NeutronQuery, QueryInterchainAccountAddressResponse},
         types::ProtobufAny,
     },
-    interchain_txs::helpers::{
+    interchain_txs::v045::helpers::{
         decode_acknowledgement_response, decode_message_response, get_port_id,
     },
     query::min_ibc_fee::query_min_ibc_fee,

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -20,7 +20,10 @@ use neutron_sdk::{
         types::ProtobufAny,
     },
     interchain_txs::helpers::{
-        decode_acknowledgement_response, decode_message_response, get_port_id,
+         decode_message_response, get_port_id,
+    },
+    interchain_txs::v047::helpers::{
+        decode_acknowledgement_response
     },
     query::min_ibc_fee::query_min_ibc_fee,
     sudo::msg::{RequestPacket, SudoMsg},
@@ -242,7 +245,7 @@ fn execute_delegate(
     }
 
     let any_msg = ProtobufAny {
-        type_url: "/cosmos.staking.v1beta1.MsgDelegate".to_string(),
+        type_url: "/cosmos.staking.v1beta1.MsgDelegateResponse".to_string(),
         value: Binary::from(buf),
     };
 
@@ -450,7 +453,7 @@ fn sudo_response(deps: DepsMut, request: RequestPacket, data: Binary) -> StdResu
 
     let mut item_types = vec![];
     for item in parsed_data {
-        let item_type = item.msg_type.as_str();
+        let item_type = item.type_url.as_str();
         item_types.push(item_type.to_string());
         match item_type {
             "/cosmos.staking.v1beta1.MsgUndelegate" => {
@@ -459,7 +462,7 @@ fn sudo_response(deps: DepsMut, request: RequestPacket, data: Binary) -> StdResu
                 // FOR LATER INSPECTION.
                 // In this particular case, a mismatch between the string message type and the
                 // serialised data layout looks like a fatal error that has to be investigated.
-                let out: MsgUndelegateResponse = decode_message_response(&item.data)?;
+                let out: MsgUndelegateResponse = decode_message_response(&item.value)?;
 
                 // NOTE: NO ERROR IS RETURNED HERE. THE CHANNEL LIVES ON.
                 // In this particular case, we demonstrate that minor errors should not
@@ -474,13 +477,13 @@ fn sudo_response(deps: DepsMut, request: RequestPacket, data: Binary) -> StdResu
                 deps.api
                     .debug(format!("Undelegation completion time: {:?}", completion_time).as_str());
             }
-            "/cosmos.staking.v1beta1.MsgDelegate" => {
+            "/cosmos.staking.v1beta1.MsgDelegateResponse" => {
                 // WARNING: RETURNING THIS ERROR CLOSES THE CHANNEL.
                 // AN ALTERNATIVE IS TO MAINTAIN AN ERRORS QUEUE AND PUT THE FAILED REQUEST THERE
                 // FOR LATER INSPECTION.
                 // In this particular case, a mismatch between the string message type and the
                 // serialised data layout looks like a fatal error that has to be investigated.
-                let _out: MsgDelegateResponse = decode_message_response(&item.data)?;
+                let _out: MsgDelegateResponse = decode_message_response(&item.value)?;
             }
             _ => {
                 deps.api.debug(

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -19,7 +19,7 @@ use neutron_sdk::{
         query::{NeutronQuery, QueryInterchainAccountAddressResponse},
         types::ProtobufAny,
     },
-    interchain_txs::v045::helpers::{
+    interchain_txs::helpers::{
         decode_acknowledgement_response, decode_message_response, get_port_id,
     },
     query::min_ibc_fee::query_min_ibc_fee,

--- a/packages/neutron-sdk/src/interchain_txs/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/helpers.rs
@@ -1,6 +1,4 @@
-use cosmos_sdk_proto::{
-    traits::Message,
-};
+use cosmos_sdk_proto::traits::Message;
 use cosmwasm_std::{StdError, StdResult};
 
 /// Decodes protobuf any item into T structure

--- a/packages/neutron-sdk/src/interchain_txs/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/helpers.rs
@@ -5,6 +5,7 @@ use cosmos_sdk_proto::{
 use cosmwasm_std::{Binary, StdError, StdResult};
 
 /// Decodes acknowledgement into `Vec<MsgData>` structure
+/// We consider this method as deprecated. Use v047 instead.
 pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> {
     let tx_msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
 

--- a/packages/neutron-sdk/src/interchain_txs/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/helpers.rs
@@ -1,39 +1,7 @@
 use cosmos_sdk_proto::{
-    cosmos::base::abci::v1beta1::{MsgData, TxMsgData},
     traits::Message,
 };
-use cosmwasm_std::{Binary, StdError, StdResult};
-
-/// Decodes acknowledgement into `Vec<MsgData>` structure
-/// We consider this method as deprecated. Use v047 instead.
-pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> {
-    let tx_msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
-
-    match tx_msg_data {
-        Err(e) => Err(StdError::generic_err(format!(
-            "Can't decode response: {}",
-            e
-        ))),
-        Ok(msg) => {
-            if !msg.msg_responses.is_empty() {
-                msg.msg_responses
-                    .into_iter()
-                    .map(|any_msg| {
-                        Ok(MsgData {
-                            msg_type: any_msg.type_url,
-                            data: any_msg.value,
-                        })
-                    })
-                    .collect::<StdResult<Vec<MsgData>>>()
-            } else {
-                // Field `.data` is deprecated since cosmos-sdk v047.
-                // But for backwards compatibility we still allow that. Given function can be used w both v045 & v047
-                #[allow(deprecated)]
-                Ok(msg.data)
-            }
-        }
-    }
-}
+use cosmwasm_std::{StdError, StdResult};
 
 /// Decodes protobuf any item into T structure
 pub fn decode_message_response<T: Message + Default>(item: &Vec<u8>) -> StdResult<T> {

--- a/packages/neutron-sdk/src/interchain_txs/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/mod.rs
@@ -1,3 +1,3 @@
-pub mod v045;
+pub mod helpers;
 
 pub mod v047;

--- a/packages/neutron-sdk/src/interchain_txs/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/mod.rs
@@ -1,3 +1,4 @@
 pub mod helpers;
 
+pub mod v045;
 pub mod v047;

--- a/packages/neutron-sdk/src/interchain_txs/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/mod.rs
@@ -1,1 +1,3 @@
-pub mod helpers;
+pub mod v045;
+
+pub mod v047;

--- a/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
@@ -25,8 +25,8 @@ pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> 
                     })
                     .collect::<StdResult<Vec<MsgData>>>()
             } else {
-                // field `.data` is deprecated since cosmos-sdk v047.
-                // but for backwards compatibility we still allow this.
+                // Field `.data` is deprecated since cosmos-sdk v047.
+                // But for backwards compatibility we still allow that. Given function can be used w both v045 & v047
                 #[allow(deprecated)]
                 Ok(msg.data)
             }

--- a/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
@@ -5,32 +5,14 @@ use cosmos_sdk_proto::{
 use cosmwasm_std::{Binary, StdError, StdResult};
 
 /// Decodes acknowledgement into `Vec<MsgData>` structure
-/// We consider this method as deprecated. Use v047 instead.
 pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> {
-    let tx_msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
-
-    match tx_msg_data {
+    let msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
+    match msg_data {
         Err(e) => Err(StdError::generic_err(format!(
             "Can't decode response: {}",
             e
         ))),
-        Ok(msg) => {
-            if !msg.msg_responses.is_empty() {
-                msg.msg_responses
-                    .into_iter()
-                    .map(|any_msg| {
-                        Ok(MsgData {
-                            msg_type: any_msg.type_url,
-                            data: any_msg.value,
-                        })
-                    })
-                    .collect::<StdResult<Vec<MsgData>>>()
-            } else {
-                // Field `.data` is deprecated since cosmos-sdk v047.
-                // But for backwards compatibility we still allow that. Given function can be used w both v045 & v047
-                #[allow(deprecated)]
-                Ok(msg.data)
-            }
-        }
+        #[allow(deprecated)]
+        Ok(msg) => Ok(msg.data),
     }
 }

--- a/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
@@ -34,12 +34,3 @@ pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> 
         }
     }
 }
-
-/// Decodes protobuf any item into T structure
-pub fn decode_message_response<T: Message + Default>(item: &Vec<u8>) -> StdResult<T> {
-    let res = T::decode(item.as_slice());
-    match res {
-        Err(e) => Err(StdError::generic_err(format!("Can't decode item: {}", e))),
-        Ok(data) => Ok(data),
-    }
-}

--- a/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/helpers.rs
@@ -1,0 +1,45 @@
+use cosmos_sdk_proto::{
+    cosmos::base::abci::v1beta1::{MsgData, TxMsgData},
+    traits::Message,
+};
+use cosmwasm_std::{Binary, StdError, StdResult};
+
+/// Decodes acknowledgement into `Vec<MsgData>` structure
+/// We consider this method as deprecated. Use v047 instead.
+pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<MsgData>> {
+    let tx_msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
+
+    match tx_msg_data {
+        Err(e) => Err(StdError::generic_err(format!(
+            "Can't decode response: {}",
+            e
+        ))),
+        Ok(msg) => {
+            if !msg.msg_responses.is_empty() {
+                msg.msg_responses
+                    .into_iter()
+                    .map(|any_msg| {
+                        Ok(MsgData {
+                            msg_type: any_msg.type_url,
+                            data: any_msg.value,
+                        })
+                    })
+                    .collect::<StdResult<Vec<MsgData>>>()
+            } else {
+                // Field `.data` is deprecated since cosmos-sdk v047.
+                // But for backwards compatibility we still allow that. Given function can be used w both v045 & v047
+                #[allow(deprecated)]
+                Ok(msg.data)
+            }
+        }
+    }
+}
+
+/// Decodes protobuf any item into T structure
+pub fn decode_message_response<T: Message + Default>(item: &Vec<u8>) -> StdResult<T> {
+    let res = T::decode(item.as_slice());
+    match res {
+        Err(e) => Err(StdError::generic_err(format!("Can't decode item: {}", e))),
+        Ok(data) => Ok(data),
+    }
+}

--- a/packages/neutron-sdk/src/interchain_txs/v045/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/mod.rs
@@ -1,1 +1,0 @@
-pub mod helpers;

--- a/packages/neutron-sdk/src/interchain_txs/v045/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v045/mod.rs
@@ -1,0 +1,1 @@
+pub mod helpers;

--- a/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
@@ -13,24 +13,3 @@ pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<Any>> {
         Ok(msg) => Ok(msg.msg_responses),
     }
 }
-
-/// Decodes protobuf any item into T structure
-pub fn decode_message_response<T: Message + Default>(item: &Vec<u8>) -> StdResult<T> {
-    let res = T::decode(item.as_slice());
-    match res {
-        Err(e) => Err(StdError::generic_err(format!("Can't decode item: {}", e))),
-        Ok(data) => Ok(data),
-    }
-}
-
-const CONTROLLER_PORT_PREFIX: &str = "icacontroller-";
-const ICA_OWNER_DELIMITER: &str = ".";
-
-/// Constructs a full ICA controller port identifier for a contract with **contract_address** and **interchain_account_id**
-/// <https://github.com/cosmos/ibc-go/blob/46e020640e66f9043c14c53a4d215a5b457d6703/modules/apps/27-interchain-accounts/types/port.go#L11>
-pub fn get_port_id<R: AsRef<str>>(contract_address: R, interchain_account_id: R) -> String {
-    CONTROLLER_PORT_PREFIX.to_string()
-        + contract_address.as_ref()
-        + ICA_OWNER_DELIMITER
-        + interchain_account_id.as_ref()
-}

--- a/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
@@ -1,7 +1,4 @@
-use cosmos_sdk_proto::{
-    cosmos::base::abci::v1beta1::TxMsgData,
-    traits::Message,
-};
+use cosmos_sdk_proto::{cosmos::base::abci::v1beta1::TxMsgData, traits::Message};
 use cosmwasm_std::{Binary, StdError, StdResult};
 use prost_types::Any;
 

--- a/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
@@ -1,0 +1,39 @@
+use cosmos_sdk_proto::{
+    cosmos::base::abci::v1beta1::{MsgData, TxMsgData},
+    traits::Message,
+};
+use cosmwasm_std::{Binary, StdError, StdResult};
+use prost_types::Any;
+
+/// Decodes acknowledgement into `Vec<MsgData>` structure
+pub fn decode_acknowledgement_response(data: Binary) -> StdResult<Vec<Any>> {
+    let msg_data: Result<TxMsgData, _> = TxMsgData::decode(data.as_slice());
+    match msg_data {
+        Err(e) => Err(StdError::generic_err(format!(
+            "Can't decode response: {}",
+            e
+        ))),
+        Ok(msg) => Ok(msg.msg_responses),
+    }
+}
+
+/// Decodes protobuf any item into T structure
+pub fn decode_message_response<T: Message + Default>(item: &Vec<u8>) -> StdResult<T> {
+    let res = T::decode(item.as_slice());
+    match res {
+        Err(e) => Err(StdError::generic_err(format!("Can't decode item: {}", e))),
+        Ok(data) => Ok(data),
+    }
+}
+
+const CONTROLLER_PORT_PREFIX: &str = "icacontroller-";
+const ICA_OWNER_DELIMITER: &str = ".";
+
+/// Constructs a full ICA controller port identifier for a contract with **contract_address** and **interchain_account_id**
+/// <https://github.com/cosmos/ibc-go/blob/46e020640e66f9043c14c53a4d215a5b457d6703/modules/apps/27-interchain-accounts/types/port.go#L11>
+pub fn get_port_id<R: AsRef<str>>(contract_address: R, interchain_account_id: R) -> String {
+    CONTROLLER_PORT_PREFIX.to_string()
+        + contract_address.as_ref()
+        + ICA_OWNER_DELIMITER
+        + interchain_account_id.as_ref()
+}

--- a/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v047/helpers.rs
@@ -1,5 +1,5 @@
 use cosmos_sdk_proto::{
-    cosmos::base::abci::v1beta1::{MsgData, TxMsgData},
+    cosmos::base::abci::v1beta1::TxMsgData,
     traits::Message,
 };
 use cosmwasm_std::{Binary, StdError, StdResult};

--- a/packages/neutron-sdk/src/interchain_txs/v047/mod.rs
+++ b/packages/neutron-sdk/src/interchain_txs/v047/mod.rs
@@ -1,0 +1,1 @@
+pub mod helpers;


### PR DESCRIPTION
[TASK](https://hadronlabs.atlassian.net/browse/NTRN-223)

related prs:
https://github.com/neutron-org/neutron-dev-contracts/pull/43
https://github.com/neutron-org/neutron-integration-tests/pull/271