### PR TITLE
Chore: deprecated unused structs

### DIFF
--- a/packages/neutron-sdk/src/bindings/msg.rs
+++ b/packages/neutron-sdk/src/bindings/msg.rs
@@ -360,6 +360,10 @@ impl NeutronMsg {
         }
     }
 
+    #[deprecated(
+        since = "0.11.0",
+        note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use submit_proposal_execute_message instead"
+    )]
     /// Basic helper to define an  ibc upgrade proposal passed to AdminModule:
     /// * **proposal** is struct which contains proposal that upgrades network.
     pub fn submit_upgrade_proposal(proposal: UpgradeProposal) -> Self {
@@ -368,6 +372,10 @@ impl NeutronMsg {
         }
     }
 
+    #[deprecated(
+        since = "0.11.0",
+        note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use submit_proposal_execute_message instead"
+    )]
     /// Basic helper to define an ibc update client change proposal passed to AdminModule:
     /// * **proposal** is struct which contains proposal updates cliient.
     pub fn submit_client_update_proposal(proposal: ClientUpdateProposal) -> Self {
@@ -572,10 +580,18 @@ pub enum AdminProposal {
     /// New params has their own `MsgUpdateParams` msgs that can be supplied to `ProposalExecuteMessage`
     ParamChangeProposal(ParamChangeProposal),
 
-    /// Proposal to upgrade IBC client
+    #[deprecated(
+        since = "0.11.0",
+        note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use ProposalExecuteMessage instead"
+    )]
+    /// Depreacteed Proposal to upgrade IBC client
     UpgradeProposal(UpgradeProposal),
 
-    /// Proposal to update IBC client
+    #[deprecated(
+        since = "0.11.0",
+        note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use ProposalExecuteMessage instead"
+    )]
+    /// Deprecated. Proposal to update IBC client
     ClientUpdateProposal(ClientUpdateProposal),
 
     /// Proposal to execute CosmosMsg.
@@ -670,6 +686,10 @@ pub struct Plan {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[deprecated(
+    since = "0.11.0",
+    note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use ProposalExecuteMessage instead"
+)]
 /// UpgradeProposal defines the struct for IBC upgrade proposal.
 pub struct UpgradeProposal {
     /// **title** is a text title of proposal.
@@ -684,6 +704,10 @@ pub struct UpgradeProposal {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[deprecated(
+    since = "0.11.0",
+    note = "Used only for querying old proposals. Will fail if executed in a new proposal. Use ProposalExecuteMessage instead"
+)]
 /// ClientUpdateProposal defines the struct for client update proposal.
 pub struct ClientUpdateProposal {
     /// **title** is a text title of proposal.


### PR DESCRIPTION
We need to deprecate some methods and structs, since they are not useful anymore.
But we can't just delete them, since it will break serialisation of already existed proposals in DAO.

Related PR:
* https://github.com/neutron-org/neutron/pull/525