### PR TITLE
Chore: bump rust to 1.78

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ compile:
 		--mount type=volume,source="$(notdir $(CURDIR))_cache",target=/target \
 		--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
 		--platform linux/amd64 \
-		cosmwasm/workspace-optimizer:0.15.0
+		cosmwasm/workspace-optimizer:0.16.0
 
 check_contracts:
 	@cargo install cosmwasm-check

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ We provide sample contracts that either implement or consume these specification
 
 ### Environment Setup
 
-- Rust v1.73.0+
+- Rust v1.78.0+
 - `wasm32-unknown-unknown` target
 - Docker
 

--- a/contracts/neutron_interchain_txs/src/contract.rs
+++ b/contracts/neutron_interchain_txs/src/contract.rs
@@ -231,8 +231,7 @@ fn execute_delegate(
             amount: amount.to_string(),
         }),
     };
-    let mut buf = Vec::new();
-    buf.reserve(delegate_msg.encoded_len());
+    let mut buf = Vec::with_capacity(delegate_msg.encoded_len());
 
     if let Err(e) = delegate_msg.encode(&mut buf) {
         return Err(NeutronError::Std(StdError::generic_err(format!(
@@ -290,8 +289,7 @@ fn execute_undelegate(
             amount: amount.to_string(),
         }),
     };
-    let mut buf = Vec::new();
-    buf.reserve(delegate_msg.encoded_len());
+    let mut buf = Vec::with_capacity(delegate_msg.encoded_len());
 
     if let Err(e) = delegate_msg.encode(&mut buf) {
         return Err(NeutronError::Std(StdError::generic_err(format!(

--- a/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v045/testing.rs
@@ -140,7 +140,7 @@ fn test_bank_total_supply_reconstruct() {
             let s = StorageValue {
                 storage_prefix: "".to_string(),
                 key: Binary::new(denom_key),
-                value: Binary::new(case.amount.as_str().as_bytes().to_vec()),
+                value: Binary::new(case.amount.as_bytes().to_vec()),
             };
             st_values.push(s);
         }

--- a/packages/neutron-sdk/src/interchain_queries/v047/testing.rs
+++ b/packages/neutron-sdk/src/interchain_queries/v047/testing.rs
@@ -139,7 +139,7 @@ fn test_bank_total_supply_reconstruct() {
             let s = StorageValue {
                 storage_prefix: "".to_string(),
                 key: Binary::new(denom_key),
-                value: Binary::new(case.amount.as_str().as_bytes().to_vec()),
+                value: Binary::new(case.amount.as_bytes().to_vec()),
             };
             st_values.push(s);
         }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73.0"
+channel = "1.78.0"


### PR DESCRIPTION
This PR bumps:
* Rust to v1.78
* CosmWasm Optimizer to v0.16.0