### PR TITLE
feat: add ability to fetch fees when they're disabled #ntrn-503

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ overflow-checks = true
 
 [workspace.dependencies]
 cosmwasm-std = "2.1.0"
-neutron-std = { git = "https://github.com/neutron-org/neutron-std", branch = "main" }
+neutron-std = { git = "https://github.com/neutron-org/neutron-std", branch = "feat/disable-feerefunder-fee" }
 cosmwasm-schema = { version = "2.1.0", default-features = false }
 cw2 = "2.0.0"
 cw-storage-plus = "2.0.0"

--- a/contracts/ibc_transfer/src/contract.rs
+++ b/contracts/ibc_transfer/src/contract.rs
@@ -156,7 +156,7 @@ fn execute_send(
         }),
         timeout_timestamp: 0,
         memo: "".to_string(),
-        fee: Some(fee.clone()),
+        fee: fee.clone(),
     };
     let msg2 = MsgTransfer {
         source_port: "transfer".to_string(),
@@ -173,7 +173,7 @@ fn execute_send(
         }),
         timeout_timestamp: 0,
         memo: "".to_string(),
-        fee: Some(fee.clone()),
+        fee: fee.clone(),
     };
     // prepare first transfer message with payload of Type1
     let submsg1 = msg_with_sudo_callback(


### PR DESCRIPTION
modify submit_tx to use Option for fees (None if no fees)


https://hadronlabs.atlassian.net/browse/NTRN-503

PR's:
- [neutron](https://github.com/neutron-org/neutron/pull/932) - add EnableFee param
- [integration-tests](https://github.com/neutron-org/neutron-integration-tests/pull/389) - add tests when fee is disabled
- [neutronjsplus](https://github.com/neutron-org/neutronjsplus/pull/86) - add param to update params proposal
- [neutronjs](https://github.com/neutron-org/neutronjs/pull/18) - add param to neutronjs
- [neutron-std](https://github.com/neutron-org/neutron-std/pull/14) - regen neutron feerefunder types
- [neutron-sdk](https://github.com/neutron-org/neutron-sdk/pull/175) - use updated neutron std to modify submit_tx to use Option for fees (None if no fees)
- [neutron-dev-contracts](https://github.com/neutron-org/neutron-dev-contracts/pull/77) - add ability to set empty fees
